### PR TITLE
Remove () from uuid field

### DIFF
--- a/courts/models.py
+++ b/courts/models.py
@@ -40,7 +40,7 @@ class MapAPIKey(SingleActiveModel):
 
 # Court model for db structure for basketball court
 class Court(models.Model):
-    id = models.CharField(primary_key=True, default=uuid.uuid4(), max_length=50, editable=True, unique=True)
+    id = models.CharField(primary_key=True, default=uuid.uuid4, max_length=50, editable=True, unique=True)
     name = models.CharField(max_length=100, blank=False)
     description = models.CharField(max_length=100, blank=True)
 


### PR DESCRIPTION
With the parenthesis, everytime `makemigrations` is executed, it generates a migration with a new `uuid4()` value. 
You can run `makemigrations` indefinitely and the migrations will continue to be created. This is not what you want.

[Reference](https://docs.djangoproject.com/en/3.1/ref/models/fields/#uuidfield)